### PR TITLE
Replace site-shot.com by www.googleapis.com/pagespeedonline

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Thumbnail URL image
 Plugin URI: https://github.com/prog-it/yourls-thumbnail-url
 Description: Add .i to shorturls to display Thumbnail URL image
-Version: 1.1
+Version: 1.2
 Author: progit
 Author URI: https://github.com/prog-it
 */
@@ -13,7 +13,8 @@ Author URI: https://github.com/prog-it
 // Thumbnail Image service URL with params
 // Choose one. Uncomment if need
 
-define( 'PROGIT_THUMB_URL', 'https://api.site-shot.com/?width=1024&height=768&scaled_width=800&format=jpeg&url=' );
+define( 'PROGIT_THUMB_URL', 'https://www.googleapis.com/pagespeedonline/v2/runPagespeed?screenshot=true&url=' );
+//define( 'PROGIT_THUMB_URL', 'https://api.site-shot.com/?width=1024&height=768&scaled_width=800&format=jpeg&url=' );
 //define( 'PROGIT_THUMB_URL', 'https://api.webthumbnail.org/?width=800&height=600&screen=1024&url=' );
 
 // Kick in if the loader does not recognize a valid pattern
@@ -30,7 +31,15 @@ function progit_yourls_thumbnail( $request ) {
 		if( yourls_is_shorturl( $keyword ) ) {
 			$url = yourls_get_keyword_longurl( $keyword );					
 			// Show the Thubmnail long URL then!
-			header('Location: '.PROGIT_THUMB_URL . $url);
+	 		$screen_shot_json_data = file_get_contents(PROGIT_THUMB_URL . $url);
+ 			$screen_shot_result = json_decode($screen_shot_json_data, true);
+ 			$screen_shot = $screen_shot_result['screenshot']['data'];
+ 			$screen_shot = str_replace(array('_','-'), array('/', '+'), $screen_shot);
+			$code_binary = base64_decode($screen_shot);
+			$image= imagecreatefromstring($code_binary);
+			header('Content-Type: image/jpeg');
+			imagejpeg($image);
+			imagedestroy($image);
 			exit;
 		}
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -13,7 +13,7 @@ Author URI: https://github.com/prog-it
 // Thumbnail Image service URL with params
 // Choose one. Uncomment if need
 
-define( 'PROGIT_THUMB_URL', 'https://www.googleapis.com/pagespeedonline/v2/runPagespeed?screenshot=true&url=' );
+define( 'PROGIT_THUMB_URL', 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?screenshot=true&url=' );
 //define( 'PROGIT_THUMB_URL', 'https://api.site-shot.com/?width=1024&height=768&scaled_width=800&format=jpeg&url=' );
 //define( 'PROGIT_THUMB_URL', 'https://api.webthumbnail.org/?width=800&height=600&screen=1024&url=' );
 
@@ -23,18 +23,18 @@ yourls_add_action( 'loader_failed', 'progit_yourls_thumbnail' );
 function progit_yourls_thumbnail( $request ) {
 	// Get authorized charset in keywords and make a regexp pattern
 	$pattern = yourls_make_regexp_pattern( yourls_get_shorturl_charset() );
-	
+
 	// Shorturl is like bleh.i ?
 	if( preg_match( "@^([$pattern]+)\.i?/?$@", $request[0], $matches ) ) {
 		// this shorturl exists ?
 		$keyword = yourls_sanitize_keyword( $matches[1] );
 		if( yourls_is_shorturl( $keyword ) ) {
-			$url = yourls_get_keyword_longurl( $keyword );					
+			$url = yourls_get_keyword_longurl( $keyword );
 			// Show the Thubmnail long URL then!
 	 		$screen_shot_json_data = file_get_contents(PROGIT_THUMB_URL . $url);
  			$screen_shot_result = json_decode($screen_shot_json_data, true);
- 			$screen_shot = $screen_shot_result['screenshot']['data'];
- 			$screen_shot = str_replace(array('_','-'), array('/', '+'), $screen_shot);
+ 			$screen_shot = $screen_shot_result['lighthouseResult']['audits']['final-screenshot']['details']['data'];
+			$screen_shot = explode(",", $screen_shot)[1];
 			$code_binary = base64_decode($screen_shot);
 			$image= imagecreatefromstring($code_binary);
 			header('Content-Type: image/jpeg');


### PR DESCRIPTION
I use www.googleapis.com/pagespeedonline to get a screenshot. It can be slow but it works fine and it's free.